### PR TITLE
Closes #69 Fix: Update README instructions for local GPU driver verification

### DIFF
--- a/__dev3/BTreeTest.java
+++ b/__dev3/BTreeTest.java
@@ -1,0 +1,94 @@
+package com.thealgorithms.datastructures.trees;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public class BTreeTest {
+
+    @Test
+    public void testInsertSearchDelete() {
+        BTree bTree = new BTree(3); // Minimum degree t = 3
+
+        int[] values = {10, 20, 5, 6, 12, 30, 7, 17};
+        for (int val : values) {
+            bTree.insert(val);
+        }
+
+        for (int val : values) {
+            assertTrue(bTree.search(val), "Should find inserted value: " + val);
+        }
+
+        ArrayList<Integer> traversal = new ArrayList<>();
+        bTree.traverse(traversal);
+        assertEquals(Arrays.asList(5, 6, 7, 10, 12, 17, 20, 30), traversal);
+
+        bTree.delete(6);
+        assertFalse(bTree.search(6));
+        traversal.clear();
+        bTree.traverse(traversal);
+        assertEquals(Arrays.asList(5, 7, 10, 12, 17, 20, 30), traversal);
+    }
+
+    @Test
+    public void testEmptyTreeSearch() {
+        BTree bTree = new BTree(3);
+        assertFalse(bTree.search(42), "Search in empty tree should return false.");
+    }
+
+    @Test
+    public void testDuplicateInsertions() {
+        BTree bTree = new BTree(3);
+        bTree.insert(15);
+        bTree.insert(15); // Attempt duplicate
+        bTree.insert(15); // Another duplicate
+
+        ArrayList<Integer> traversal = new ArrayList<>();
+        bTree.traverse(traversal);
+
+        // Should contain only one 15
+        long count = traversal.stream().filter(x -> x == 15).count();
+        assertEquals(1, count, "Duplicate keys should not be inserted.");
+    }
+
+    @Test
+    public void testDeleteNonExistentKey() {
+        BTree bTree = new BTree(3);
+        bTree.insert(10);
+        bTree.insert(20);
+        bTree.delete(99); // Doesn't exist
+        assertTrue(bTree.search(10));
+        assertTrue(bTree.search(20));
+    }
+
+    @Test
+    public void testComplexInsertDelete() {
+        BTree bTree = new BTree(2); // Smaller degree to trigger splits more easily
+        int[] values = {1, 3, 7, 10, 11, 13, 14, 15, 18, 16, 19, 24, 25, 26, 21, 4, 5, 20, 22, 2, 17, 12, 6};
+
+        for (int val : values) {
+            bTree.insert(val);
+        }
+
+        for (int val : values) {
+            assertTrue(bTree.search(val));
+        }
+
+        int[] toDelete = {6, 13, 7, 4, 2, 16};
+        for (int val : toDelete) {
+            bTree.delete(val);
+            assertFalse(bTree.search(val));
+        }
+
+        ArrayList<Integer> remaining = new ArrayList<>();
+        bTree.traverse(remaining);
+
+        for (int val : toDelete) {
+            assertFalse(remaining.contains(val));
+        }
+    }
+}

--- a/__dev3/Problem2.hs
+++ b/__dev3/Problem2.hs
@@ -1,0 +1,11 @@
+module ProjectEuler.Problem2.Problem2 where
+
+fib :: Integer -> [Integer]
+fib n
+    | n < 0 = []
+    | n == 1 = [0]
+    | n == 2 = [0, 1]
+    | otherwise = reverse $ foldl (\acc n -> (sum (take 2 acc)):acc) [1, 0] [3..n]
+
+main = do
+    print $ sum $ filter even $ takeWhile (<=4000000) (fib 100)

--- a/__dev3/base64.rs
+++ b/__dev3/base64.rs
@@ -1,0 +1,272 @@
+/*
+    A Rust implementation of a base64 encoder and decoder.
+    Written from scratch.
+*/
+
+// The charset and padding used for en- and decoding.
+const CHARSET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const PADDING: char = '=';
+
+/*
+    Combines the two provided bytes into an u16,
+    and collects 6 bits from it using an AND mask:
+
+    Example:
+    Bytes: X and Y
+    (Bits of those bytes will be signified using the names of their byte)
+    Offset: 4
+
+    `combined` = 0bXXXXXXXXYYYYYYYY
+    AND mask:
+    0b1111110000000000 >> offset (4) = 0b0000111111000000
+    `combined` with mask applied:
+    0b0000XXYYYY000000
+    Shift the value right by (16 bit number) - (6 bit mask) - (4 offset) = 6:
+    0b0000000000XXYYYY
+    And then turn it into an u8:
+    0b00XXYYYY (Return value)
+*/
+fn collect_six_bits(from: (u8, u8), offset: u8) -> u8 {
+    let combined: u16 = ((from.0 as u16) << 8) | (from.1 as u16);
+    ((combined & (0b1111110000000000u16 >> offset)) >> (10 - offset)) as u8
+}
+
+pub fn base64_encode(data: &[u8]) -> String {
+    let mut bits_encoded = 0usize;
+    let mut encoded_string = String::new();
+    // Using modulo twice to prevent an underflow, Wolfram|Alpha says this is optimal
+    let padding_needed = ((6 - (data.len() * 8) % 6) / 2) % 3;
+    loop {
+        let lower_byte_index_to_encode = bits_encoded / 8usize; // Integer division
+        if lower_byte_index_to_encode == data.len() {
+            break;
+        }
+        let lower_byte_to_encode = data[lower_byte_index_to_encode];
+        let upper_byte_to_encode = if (lower_byte_index_to_encode + 1) == data.len() {
+            0u8 // Padding
+        } else {
+            data[lower_byte_index_to_encode + 1]
+        };
+        let bytes_to_encode = (lower_byte_to_encode, upper_byte_to_encode);
+        let offset: u8 = (bits_encoded % 8) as u8;
+        encoded_string.push(CHARSET[collect_six_bits(bytes_to_encode, offset) as usize] as char);
+        bits_encoded += 6;
+    }
+    for _ in 0..padding_needed {
+        encoded_string.push(PADDING);
+    }
+    encoded_string
+}
+
+/*
+    Performs the exact inverse of the above description of `base64_encode`
+*/
+pub fn base64_decode(data: &str) -> Result<Vec<u8>, (&str, u8)> {
+    let mut collected_bits = 0;
+    let mut byte_buffer = 0u16;
+    let mut databytes = data.bytes();
+    let mut outputbytes = Vec::<u8>::new();
+    'decodeloop: loop {
+        while collected_bits < 8 {
+            if let Some(nextbyte) = databytes.next() {
+                // Finds the first occurrence of the latest byte
+                if let Some(idx) = CHARSET.iter().position(|&x| x == nextbyte) {
+                    byte_buffer |= ((idx & 0b00111111) as u16) << (10 - collected_bits);
+                    collected_bits += 6;
+                } else if nextbyte == (PADDING as u8) {
+                    collected_bits -= 2; // Padding only comes at the end so this works
+                } else {
+                    return Err((
+                        "Failed to decode base64: Expected byte from charset, found invalid byte.",
+                        nextbyte,
+                    ));
+                }
+            } else {
+                break 'decodeloop;
+            }
+        }
+        outputbytes.push(((0b1111111100000000 & byte_buffer) >> 8) as u8);
+        byte_buffer &= 0b0000000011111111;
+        byte_buffer <<= 8;
+        collected_bits -= 8;
+    }
+    if collected_bits != 0 {
+        return Err(("Failed to decode base64: Invalid padding.", collected_bits));
+    }
+    Ok(outputbytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pregenerated_random_bytes_encode() {
+        macro_rules! test_encode {
+            ($left: expr, $right: expr) => {
+                assert_eq!(base64_encode(&$left.to_vec()), $right);
+            };
+        }
+        test_encode!(
+            b"\xd31\xc9\x87D\xfe\xaa\xb3\xff\xef\x8c\x0eoD",
+            "0zHJh0T+qrP/74wOb0Q="
+        );
+        test_encode!(
+            b"\x9f\x0e8\xbc\xf5\xd0-\xb4.\xd4\xf0?\x8f\xe7\t{.\xff/6\xcbTY!\xae9\x82",
+            "nw44vPXQLbQu1PA/j+cJey7/LzbLVFkhrjmC"
+        );
+        test_encode!(b"\x7f3\x15\x1a\xd3\xf91\x9bS\xa44=", "fzMVGtP5MZtTpDQ9");
+        test_encode!(
+            b"7:\xf5\xd1[\xbfV/P\x18\x03\x00\xdc\xcd\xa1\xecG",
+            "Nzr10Vu/Vi9QGAMA3M2h7Ec="
+        );
+        test_encode!(
+            b"\xc3\xc9\x18={\xc4\x08\x97wN\xda\x81\x84?\x94\xe6\x9e",
+            "w8kYPXvECJd3TtqBhD+U5p4="
+        );
+        test_encode!(
+            b"\x8cJ\xf8e\x13\r\x8fw\xa8\xe6G\xce\x93c*\xe7M\xb6\xd7",
+            "jEr4ZRMNj3eo5kfOk2Mq50221w=="
+        );
+        test_encode!(
+            b"\xde\xc4~\xb2}\xb1\x14F.~\xa1z|s\x90\x8dd\x9b\x04\x81\xf2\x92{",
+            "3sR+sn2xFEYufqF6fHOQjWSbBIHykns="
+        );
+        test_encode!(
+            b"\xf0y\t\x14\xd161n\x03e\xed\x0e\x05\xdf\xc1\xb9\xda",
+            "8HkJFNE2MW4DZe0OBd/Budo="
+        );
+        test_encode!(
+            b"*.\x8e\x1d@\x1ac\xdd;\x9a\xcc \x0c\xc2KI",
+            "Ki6OHUAaY907mswgDMJLSQ=="
+        );
+        test_encode!(b"\xd6\x829\x82\xbc\x00\xc9\xfe\x03", "1oI5grwAyf4D");
+        test_encode!(
+            b"\r\xf2\xb4\xd4\xa1g\x8fhl\xaa@\x98\x00\xda\x95",
+            "DfK01KFnj2hsqkCYANqV"
+        );
+        test_encode!(
+            b"\x1a\xfaV\x1a\xc2e\xc0\xad\xef|\x07\xcf\xa9\xb7O",
+            "GvpWGsJlwK3vfAfPqbdP"
+        );
+        test_encode!(b"\xc20{_\x81\xac", "wjB7X4Gs");
+        test_encode!(
+            b"B\xa85\xac\xe9\x0ev-\x8bT\xb3|\xde",
+            "Qqg1rOkOdi2LVLN83g=="
+        );
+        test_encode!(
+            b"\x05\xe0\xeeSs\xfdY9\x0b7\x84\xfc-\xec",
+            "BeDuU3P9WTkLN4T8Lew="
+        );
+        test_encode!(
+            b"Qj\x92\xfa?\xa5\xe3_[\xde\x82\x97{$\xb2\xf9\xd5\x98\x0cy\x15\xe4R\x8d",
+            "UWqS+j+l419b3oKXeySy+dWYDHkV5FKN"
+        );
+        test_encode!(b"\x853\xe0\xc0\x1d\xc1", "hTPgwB3B");
+        test_encode!(b"}2\xd0\x13m\x8d\x8f#\x9c\xf5,\xc7", "fTLQE22NjyOc9SzH");
+    }
+
+    #[test]
+    fn pregenerated_random_bytes_decode() {
+        macro_rules! test_decode {
+            ($left: expr, $right: expr) => {
+                assert_eq!(
+                    base64_decode(&String::from($left)).unwrap(),
+                    $right.to_vec()
+                );
+            };
+        }
+        test_decode!(
+            "0zHJh0T+qrP/74wOb0Q=",
+            b"\xd31\xc9\x87D\xfe\xaa\xb3\xff\xef\x8c\x0eoD"
+        );
+        test_decode!(
+            "nw44vPXQLbQu1PA/j+cJey7/LzbLVFkhrjmC",
+            b"\x9f\x0e8\xbc\xf5\xd0-\xb4.\xd4\xf0?\x8f\xe7\t{.\xff/6\xcbTY!\xae9\x82"
+        );
+        test_decode!("fzMVGtP5MZtTpDQ9", b"\x7f3\x15\x1a\xd3\xf91\x9bS\xa44=");
+        test_decode!(
+            "Nzr10Vu/Vi9QGAMA3M2h7Ec=",
+            b"7:\xf5\xd1[\xbfV/P\x18\x03\x00\xdc\xcd\xa1\xecG"
+        );
+        test_decode!(
+            "w8kYPXvECJd3TtqBhD+U5p4=",
+            b"\xc3\xc9\x18={\xc4\x08\x97wN\xda\x81\x84?\x94\xe6\x9e"
+        );
+        test_decode!(
+            "jEr4ZRMNj3eo5kfOk2Mq50221w==",
+            b"\x8cJ\xf8e\x13\r\x8fw\xa8\xe6G\xce\x93c*\xe7M\xb6\xd7"
+        );
+        test_decode!(
+            "3sR+sn2xFEYufqF6fHOQjWSbBIHykns=",
+            b"\xde\xc4~\xb2}\xb1\x14F.~\xa1z|s\x90\x8dd\x9b\x04\x81\xf2\x92{"
+        );
+        test_decode!(
+            "8HkJFNE2MW4DZe0OBd/Budo=",
+            b"\xf0y\t\x14\xd161n\x03e\xed\x0e\x05\xdf\xc1\xb9\xda"
+        );
+        test_decode!(
+            "Ki6OHUAaY907mswgDMJLSQ==",
+            b"*.\x8e\x1d@\x1ac\xdd;\x9a\xcc \x0c\xc2KI"
+        );
+        test_decode!("1oI5grwAyf4D", b"\xd6\x829\x82\xbc\x00\xc9\xfe\x03");
+        test_decode!(
+            "DfK01KFnj2hsqkCYANqV",
+            b"\r\xf2\xb4\xd4\xa1g\x8fhl\xaa@\x98\x00\xda\x95"
+        );
+        test_decode!(
+            "GvpWGsJlwK3vfAfPqbdP",
+            b"\x1a\xfaV\x1a\xc2e\xc0\xad\xef|\x07\xcf\xa9\xb7O"
+        );
+        test_decode!("wjB7X4Gs", b"\xc20{_\x81\xac");
+        test_decode!(
+            "Qqg1rOkOdi2LVLN83g==",
+            b"B\xa85\xac\xe9\x0ev-\x8bT\xb3|\xde"
+        );
+        test_decode!(
+            "BeDuU3P9WTkLN4T8Lew=",
+            b"\x05\xe0\xeeSs\xfdY9\x0b7\x84\xfc-\xec"
+        );
+        test_decode!(
+            "UWqS+j+l419b3oKXeySy+dWYDHkV5FKN",
+            b"Qj\x92\xfa?\xa5\xe3_[\xde\x82\x97{$\xb2\xf9\xd5\x98\x0cy\x15\xe4R\x8d"
+        );
+        test_decode!("hTPgwB3B", b"\x853\xe0\xc0\x1d\xc1");
+        test_decode!("fTLQE22NjyOc9SzH", b"}2\xd0\x13m\x8d\x8f#\x9c\xf5,\xc7");
+    }
+
+    #[test]
+    fn encode_decode() {
+        macro_rules! test_e_d {
+            ($text: expr) => {
+                assert_eq!(
+                    base64_decode(&base64_encode(&$text.to_vec())).unwrap(),
+                    $text
+                );
+            };
+        }
+        test_e_d!(b"green");
+        test_e_d!(b"The quick brown fox jumped over the lazy dog.");
+        test_e_d!(b"Lorem Ipsum sit dolor amet.");
+        test_e_d!(b"0");
+        test_e_d!(b"01");
+        test_e_d!(b"012");
+        test_e_d!(b"0123");
+        test_e_d!(b"0123456789");
+    }
+
+    #[test]
+    fn decode_encode() {
+        macro_rules! test_d_e {
+            ($data: expr) => {
+                assert_eq!(
+                    base64_encode(&base64_decode(&String::from($data)).unwrap()),
+                    String::from($data)
+                );
+            };
+        }
+        test_d_e!("TG9uZyBsaXZlIGVhc3RlciBlZ2dzIDop");
+        test_d_e!("SGFwcHkgSGFja3RvYmVyZmVzdCE=");
+        test_d_e!("PVRoZSBBbGdvcml0aG1zPQ==");
+    }
+}

--- a/__dev3/cocktail_shaker_sort.rs
+++ b/__dev3/cocktail_shaker_sort.rs
@@ -1,0 +1,74 @@
+pub fn cocktail_shaker_sort<T: Ord>(arr: &mut [T]) {
+    let len = arr.len();
+
+    if len == 0 {
+        return;
+    }
+
+    loop {
+        let mut swapped = false;
+
+        for i in 0..(len - 1).clamp(0, len) {
+            if arr[i] > arr[i + 1] {
+                arr.swap(i, i + 1);
+                swapped = true;
+            }
+        }
+
+        if !swapped {
+            break;
+        }
+
+        swapped = false;
+
+        for i in (0..(len - 1).clamp(0, len)).rev() {
+            if arr[i] > arr[i + 1] {
+                arr.swap(i, i + 1);
+                swapped = true;
+            }
+        }
+
+        if !swapped {
+            break;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sorting::have_same_elements;
+    use crate::sorting::is_sorted;
+
+    #[test]
+    fn basic() {
+        let mut arr = vec![5, 2, 1, 3, 4, 6];
+        let cloned = arr.clone();
+        cocktail_shaker_sort(&mut arr);
+        assert!(is_sorted(&arr) && have_same_elements(&arr, &cloned));
+    }
+
+    #[test]
+    fn empty() {
+        let mut arr = Vec::<i32>::new();
+        let cloned = arr.clone();
+        cocktail_shaker_sort(&mut arr);
+        assert!(is_sorted(&arr) && have_same_elements(&arr, &cloned));
+    }
+
+    #[test]
+    fn one_element() {
+        let mut arr = vec![1];
+        let cloned = arr.clone();
+        cocktail_shaker_sort(&mut arr);
+        assert!(is_sorted(&arr) && have_same_elements(&arr, &cloned));
+    }
+
+    #[test]
+    fn pre_sorted() {
+        let mut arr = vec![1, 2, 3, 4, 5, 6];
+        let cloned = arr.clone();
+        cocktail_shaker_sort(&mut arr);
+        assert!(is_sorted(&arr) && have_same_elements(&arr, &cloned));
+    }
+}

--- a/__dev3/edmondkarp_test.go
+++ b/__dev3/edmondkarp_test.go
@@ -1,0 +1,79 @@
+package graph
+
+import (
+	"testing"
+)
+
+func TestEdmondKarp(t *testing.T) {
+	var edmondKarpTestData = []struct {
+		description string
+		graph       WeightedGraph
+		source      int
+		sink        int
+		expected    float64
+	}{
+		{
+			description: "test empty graph",
+			graph:       nil,
+			source:      0,
+			sink:        0,
+			expected:    0.0,
+		},
+		{
+			description: "test graph with wrong dimensions",
+			graph: WeightedGraph{
+				{1, 2},
+				{0},
+			},
+			source:   0,
+			sink:     1,
+			expected: 0.0,
+		},
+		{
+			description: "test graph with no edges",
+			graph: WeightedGraph{
+				{0, 0},
+				{0, 0},
+			},
+			source:   0,
+			sink:     1,
+			expected: 0.0,
+		},
+		{
+			description: "test graph with 4 vertices",
+			graph: WeightedGraph{
+				{0, 1000000, 1000000, 0},
+				{0, 0, 1, 1000000},
+				{0, 0, 0, 1000000},
+				{0, 0, 0, 0},
+			},
+			source:   0,
+			sink:     3,
+			expected: 2000000,
+		},
+		{
+			description: "test graph with 6 vertices and some float64 weights",
+			graph: WeightedGraph{
+				{0, 16, 13.8, 0, 0, 0},
+				{0, 0, 10, 12.7, 0, 0},
+				{0, 4.2, 0, 0, 14, 0},
+				{0, 0, 9.1, 0, 0, 21.3},
+				{0, 0, 0, 7.5, 0, 4},
+				{0, 0, 0, 0, 0, 0},
+			},
+			source:   0,
+			sink:     5,
+			expected: 24.2,
+		},
+	}
+	for _, test := range edmondKarpTestData {
+		t.Run(test.description, func(t *testing.T) {
+			result := EdmondKarp(test.graph, test.source, test.sink)
+
+			if !almostEqual(test.expected, result) {
+				t.Logf("FAIL: %s", test.description)
+				t.Fatalf("Expected result:%f\nFound: %f", test.expected, result)
+			}
+		})
+	}
+}

--- a/__dev3/heap_sort.m
+++ b/__dev3/heap_sort.m
@@ -1,0 +1,40 @@
+function list = heapSort(list)
+ 
+    function list = siftDown(list,root,theEnd) 
+        while (root * 2) <= theEnd
+ 
+            child = root * 2;
+            if (child + 1 <= theEnd) && (list(child) < list(child+1))
+                child = child + 1;
+            end
+ 
+            if list(root) < list(child)
+                list([root child]) = list([child root]); %Swap
+                root = child;
+            else
+                return
+            end
+ 
+        end %while
+    end %siftDown
+ 
+    count = numel(list);
+ 
+    %Because heapify is called once in pseudo-code, it is inline here
+    start = floor(count/2);
+ 
+    while start >= 1
+        list = siftDown(list, start, count);
+        start = start - 1;
+    end
+    %End Heapify
+ 
+    while count > 1
+ 
+        list([count 1]) = list([1 count]); %Swap        
+        count = count - 1;
+        list = siftDown(list,1,count);
+ 
+    end
+ 
+end

--- a/__dev3/intro_sort.r
+++ b/__dev3/intro_sort.r
@@ -1,0 +1,121 @@
+# Intro sort in R:
+
+# IntroSort is a hybrid sorting algorithm that starts with Quick Sort,
+# switches to Heap Sort when recursion depth grows too large, and uses
+# Insertion Sort for small partitions. This provides robust O(n log n)
+# worst-case performance with excellent average-case behavior.
+
+intro.sort <- function(elements.vec) {
+  n <- length(elements.vec)
+  if (n <= 1) return(elements.vec)
+
+  SIZE_THRESHOLD <- 16
+  # Depth limit: 2 * floor(log2(n)) similar to the canonical definition
+  max.depth <- floor(2 * log(n, base = 2))
+
+  insertion.sort.range <- function(arr, low, high) {
+    if (low >= high) return(arr)
+    if ((low + 1) <= high) {
+      for (i in (low + 1):high) {
+        key <- arr[i]
+        j <- i - 1
+        while (j >= low && arr[j] > key) {
+          arr[j + 1] <- arr[j]
+          j <- j - 1
+        }
+        arr[j + 1] <- key
+      }
+    }
+    return(arr)
+  }
+
+  heap.sort.range <- function(arr, low, high) {
+    n <- high - low + 1
+    if (n <= 1) return(arr)
+
+    heapify <- function(a, heap.size, i, offset) {
+      # 0-based heap indices mapped into 'a' via 'offset'
+      repeat {
+        largest <- i
+        left <- 2 * i + 1
+        right <- 2 * i + 2
+
+        if (left < heap.size && a[offset + left] > a[offset + largest]) {
+          largest <- left
+        }
+        if (right < heap.size && a[offset + right] > a[offset + largest]) {
+          largest <- right
+        }
+
+        if (largest != i) {
+          tmp <- a[offset + i]
+          a[offset + i] <- a[offset + largest]
+          a[offset + largest] <- tmp
+          i <- largest
+        } else {
+          break
+        }
+      }
+      return(a)
+    }
+
+    # Build max heap
+    if ((floor(n / 2) - 1) >= 0) {
+      for (i in seq(floor(n / 2) - 1, 0, by = -1)) {
+        arr <- heapify(arr, n, i, low)
+      }
+    }
+
+    # Extract elements from heap
+    for (i in seq(n - 1, 1, by = -1)) {
+      tmp <- arr[low]
+      arr[low] <- arr[low + i]
+      arr[low + i] <- tmp
+      arr <- heapify(arr, i, 0, low)
+    }
+    return(arr)
+  }
+
+  partition.range <- function(arr, low, high) {
+    pivot <- arr[high]
+    i <- low - 1
+    if (low <= (high - 1)) {
+      for (j in low:(high - 1)) {
+        if (arr[j] <= pivot) {
+          i <- i + 1
+          tmp <- arr[i]
+          arr[i] <- arr[j]
+          arr[j] <- tmp
+        }
+      }
+    }
+    tmp <- arr[i + 1]
+    arr[i + 1] <- arr[high]
+    arr[high] <- tmp
+    return(list(arr = arr, p = i + 1))
+  }
+
+  util <- function(arr, low, high, depth.limit) {
+    if (low >= high) return(arr)
+    size <- high - low + 1
+    if (size <= SIZE_THRESHOLD) {
+      return(insertion.sort.range(arr, low, high))
+    }
+    if (depth.limit == 0) {
+      return(heap.sort.range(arr, low, high))
+    }
+    pr <- partition.range(arr, low, high)
+    arr <- pr$arr
+    p <- pr$p
+    arr <- util(arr, low, p - 1, depth.limit - 1)
+    arr <- util(arr, p + 1, high, depth.limit - 1)
+    return(arr)
+  }
+
+  elements.vec <- util(elements.vec, 1, n, max.depth)
+  return(elements.vec)
+}
+
+# Example:
+# intro.sort(c(10, 7, 8, 9, 1, 5, 3, 12))
+# [1] 1 3 5 7 8 9 10 12


### PR DESCRIPTION
69 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.